### PR TITLE
Update printing for the Online Python Tutor trace format.

### DIFF
--- a/tools/seec-trace-print/ClangMapped.cpp
+++ b/tools/seec-trace-print/ClangMapped.cpp
@@ -187,7 +187,8 @@ void PrintClangMappedStates(seec::cm::ProcessTrace const &Trace,
   }
 }
 
-void PrintClangMapped(seec::AugmentationCollection const &Augmentations)
+void PrintClangMapped(seec::AugmentationCollection const &Augmentations,
+                      llvm::StringRef OPTVariableName)
 {
   // Attempt to setup the trace reader.
   auto MaybeIBA = seec::trace::InputBufferAllocator::createFor(InputDirectory);
@@ -218,6 +219,8 @@ void PrintClangMapped(seec::AugmentationCollection const &Augmentations)
   }
   else if (OnlinePythonTutor) {
     PrintOnlinePythonTutor(*CMProcessTrace,
-                           OPTSettings{}.setPyCrazyMode(true));
+                           OPTSettings{Augmentations}
+                            .setPyCrazyMode(false)
+                            .setVariableName(OPTVariableName));
   }
 }

--- a/tools/seec-trace-print/ClangMapped.hpp
+++ b/tools/seec-trace-print/ClangMapped.hpp
@@ -14,10 +14,13 @@
 #ifndef SEEC_TRACE_PRINT_CLANGMAPPED_HPP
 #define SEEC_TRACE_PRINT_CLANGMAPPED_HPP
 
+#include "llvm/ADT/StringRef.h"
+
 namespace seec {
   class AugmentationCollection;
 }
 
-void PrintClangMapped(seec::AugmentationCollection const &Augmentations);
+void PrintClangMapped(seec::AugmentationCollection const &Augmentations,
+                      llvm::StringRef OPTVariableName);
 
 #endif // SEEC_TRACE_PRINT_CLANGMAPPED_HPP

--- a/tools/seec-trace-print/OnlinePythonTutor.hpp
+++ b/tools/seec-trace-print/OnlinePythonTutor.hpp
@@ -14,24 +14,46 @@
 #ifndef SEEC_TRACE_PRINT_ONLINEPYTHONTUTOR_HPP
 #define SEEC_TRACE_PRINT_ONLINEPYTHONTUTOR_HPP
 
+#include "llvm/ADT/StringRef.h"
+
+#include <string>
+
 namespace seec {
   namespace cm {
     class ProcessTrace;
   }
+  class AugmentationCollection;
 }
 
 class OPTSettings {
+  seec::AugmentationCollection const &Augmentations;
+
   bool PyCrazyMode;
 
+  std::string VariableName;
+
 public:
-  OPTSettings()
-  : PyCrazyMode(false)
+  OPTSettings(seec::AugmentationCollection const &WithAugmentations)
+  : Augmentations(WithAugmentations),
+    PyCrazyMode(false),
+    VariableName()
   {}
+
+  seec::AugmentationCollection const &getAugmentations() const {
+    return Augmentations;
+  }
 
   bool getPyCrazyMode() const { return PyCrazyMode; }
 
   OPTSettings &setPyCrazyMode(bool const Value) {
     PyCrazyMode = Value;
+    return *this;
+  }
+
+  std::string const &getVariableName() const { return VariableName; }
+
+  OPTSettings &setVariableName(llvm::StringRef Value) {
+    VariableName = Value;
     return *this;
   }
 };

--- a/tools/seec-trace-print/main.cpp
+++ b/tools/seec-trace-print/main.cpp
@@ -94,6 +94,9 @@ namespace seec {
     cl::opt<bool>
     OnlinePythonTutor("P", cl::desc("output suitable for Online Python Tutor"));
 
+    cl::opt<std::string>
+    OPTVariableName("opt-var-name", cl::desc("for Online Python Tutor trace output, create a variable with this name"));
+
     cl::opt<bool>
     ReverseStates("reverse", cl::desc("show reverse iterated states at the end"));
 
@@ -158,7 +161,7 @@ int main(int argc, char **argv, char * const *envp) {
   Augmentations.loadFromUserLocalDataDir();
 
   if (UseClangMapping || OnlinePythonTutor) {
-    PrintClangMapped(Augmentations);
+    PrintClangMapped(Augmentations, OPTVariableName);
   }
   else {
     PrintUnmapped(Augmentations);


### PR DESCRIPTION
Online Python Tutor has upcoming support for C/C++ visualization. The front-end
now supports some C/C++ features which the old trace format couldn't handle,
e.g. arrays and structs allocated on the stack, and pointers to sub-objects of
heap allocations.

This commit updates SeeC's OPT trace format output to use these new features.
Also, runtime errors are now expressed in the trace (using OPT's support for
exceptions).
