### PR TITLE
Make indicators user-configurable.

### DIFF
--- a/resources/TraceViewer/HTML/StateGraphViewer.html
+++ b/resources/TraceViewer/HTML/StateGraphViewer.html
@@ -15,7 +15,7 @@
 
     a:hover { cursor: context-menu; z-index:100; }
     a:hover > path { z-index:105; }
-    a:hover > polygon { fill-opacity:1; z-index:100; }
+    a:hover > polygon { z-index:100; }
     a:hover > text { z-index:110; }
 
     polygon.uninitialized ~ polygon { fill: none; }
@@ -224,6 +224,15 @@
         }
       });
 
+      // for each text element, take the inner text and put it into a tspan.
+      // this allows us to style decorations (underlining) differently to the text.
+      $('text').each(function(index, element) {
+        var tspan = document.createElementNS("http://www.w3.org/2000/svg", "tspan");
+        tspan.textContent = element.textContent;
+        element.textContent = "";
+        element.appendChild(tspan);
+      });
+
       StateExists = true;
 
       for (var i = 0; i < HighlightedValues.length; ++i)
@@ -299,24 +308,40 @@
 
     // Called from seec-view to set the ColourScheme.
     //
-    function SetColourScheme(Scheme) {
-      ColourScheme = Scheme;
+    function SetColourScheme(ColourScheme) {
       var CSSTemplate = 
         "body { background-color:$BODY_BG; }\n"
       + "text { fill:$TEXT_FILL; }\n"
       + "g.graph > polygon { stroke:none; fill:$GRAPH_POLY_FILL; }\n"
       + "polygon { stroke:$POLY_STROKE; fill:$POLY_FILL; }\n"
       + "path { stroke:$PATH_STROKE; }\n"
-      + "polygon.uninitialized { fill:$UNINITIALIZED_POLY_FILL; }\n"
-      + ".activestmtvalue > path { stroke:$ACTIVESTMTVALUE_PATH_STROKE; }\n"
-      + ".activestmtvalue > polygon { stroke:$ACTIVESTMTVALUE_POLY_STROKE; fill:$ACTIVESTMTVALUE_POLY_FILL; }\n"
-      + ".activestmtvalue > text { fill:$ACTIVESTMTVALUE_TEXT_FILL; }\n"
-      + ".valuehighlight > path { stroke:$VALUEHIGHLIGHT_PATH_STROKE; }\n"
-      + ".valuehighlight > polygon { stroke:$VALUEHIGHLIGHT_POLY_STROKE; fill:$VALUEHIGHLIGHT_POLY_FILL; }\n"
-      + ".valuehighlight > text { fill:$VALUEHIGHLIGHT_TEXT_FILL; }\n"
-      + "a:hover > path { stroke:$ANCHORHOVER_PATH_STROKE; }\n"
-      + "a:hover > polygon { stroke:$ANCHORHOVER_POLY_STROKE; fill:$ANCHORHOVER_POLY_FILL; }\n"
-      + "a:hover > text { fill:$ANCHORHOVER_TEXT_FILL; }\n";
+      + "polygon.uninitialized { fill:$UNINITIALIZED_POLY_FILL; }\n";
+
+      var SetupSchemeForSelector = function(Scheme, Default, Selector) {
+        if (Scheme.Kind == "PLAIN") {
+          // We have to handle g.edge descendents separately, so that pointers get some useful highlighting.
+          CSSTemplate += Selector + " text { text-decoration: underline; fill: " + Scheme.Foreground + "; }\n"
+                       + Selector + " tspan { fill: " + Default.Foreground + "; }\n"
+                       + "g.edge " + Selector + " > path { stroke:" + Scheme.Foreground + "; }\n"
+                       + "g.edge " + Selector + " > polygon { stroke:" + Scheme.Foreground + "; }\n";
+        }
+        else if (Scheme.Kind == "BOX") {
+          CSSTemplate += Selector + " > path { stroke:" + Scheme.Foreground + "; stroke-opacity:1; }\n"
+                       + Selector + " > polygon { stroke:" + Scheme.Foreground + "; stroke-opacity:1; fill-opacity:0; }\n";
+        }
+        else if (Scheme.Kind == "STRAIGHTBOX") {
+          StrokeOpacity = Scheme.OutlineAlpha / 255.0;
+          FillOpacity = Scheme.Alpha / 255.0;
+          
+          CSSTemplate += Selector + " > path { stroke:" + Scheme.Foreground + "; stroke-opacity:" + StrokeOpacity + "; }\n"
+                       + Selector + " > polygon { stroke:" + Scheme.Foreground + "; stroke-opacity:" + StrokeOpacity + "; fill:" + Scheme.Foreground + "; fill-opacity:" + FillOpacity + "; }\n";  
+        }
+      };
+      
+      // Later entries take preference.
+      SetupSchemeForSelector(ColourScheme.ActiveCode,    ColourScheme.Default, ".activestmtvalue");
+      SetupSchemeForSelector(ColourScheme.HighlightCode, ColourScheme.Default, "a:hover");
+      SetupSchemeForSelector(ColourScheme.HighlightCode, ColourScheme.Default, ".valuehighlight");
 
       // Transform the CSSTemplate according to the ColourScheme.
       var SchemedCSS = CSSTemplate
@@ -326,19 +351,9 @@
         .replace("$PATH_STROKE", ColourScheme.Default.Foreground)
         .replace("$BODY_BG",     ColourScheme.Default.Background)
         .replace("$TEXT_FILL",   ColourScheme.Default.Foreground)
-        .replace("$UNINITIALIZED_POLY_FILL", "#aaaaaa")
-        .replace("$ACTIVESTMTVALUE_PATH_STROKE", ColourScheme.RuntimeValue.Foreground)
-        .replace("$ACTIVESTMTVALUE_POLY_STROKE", ColourScheme.RuntimeValue.Foreground)
-        .replace("$ACTIVESTMTVALUE_POLY_FILL",   ColourScheme.RuntimeValue.Background)
-        .replace("$ACTIVESTMTVALUE_TEXT_FILL",   ColourScheme.RuntimeValue.Foreground)
-        .replace("$VALUEHIGHLIGHT_PATH_STROKE", ColourScheme.RuntimeInformation.Foreground)
-        .replace("$VALUEHIGHLIGHT_POLY_STROKE", ColourScheme.RuntimeInformation.Foreground)
-        .replace("$VALUEHIGHLIGHT_POLY_FILL",   ColourScheme.RuntimeInformation.Background)
-        .replace("$VALUEHIGHLIGHT_TEXT_FILL",   ColourScheme.RuntimeInformation.Foreground)
-        .replace("$ANCHORHOVER_PATH_STROKE", ColourScheme.RuntimeInformation.Foreground)
-        .replace("$ANCHORHOVER_POLY_STROKE", ColourScheme.RuntimeInformation.Foreground)
-        .replace("$ANCHORHOVER_POLY_FILL",   ColourScheme.RuntimeInformation.Background)
-        .replace("$ANCHORHOVER_TEXT_FILL",   ColourScheme.RuntimeInformation.Foreground);
+        .replace("$UNINITIALIZED_POLY_FILL", "#aaaaaa");
+
+      Log(SchemedCSS);
 
       var theStyle = document.getElementById('theStyle');
       theStyle.innerHTML = SchemedCSS;

--- a/resources/TraceViewer/root.txt
+++ b/resources/TraceViewer/root.txt
@@ -718,8 +718,10 @@ root:table {
     FontInfoNodeMissing:string {"FontInfo node is missing from TextStyle definition for '{value}'."}
     XMLLoadError:string {"Failed to read colour scheme XML document '{filename}'."}
     TextStylesMissing:string {"Text styles node is missing from colour scheme."}
+    IndicatorStylesMissing:string {"Indicator styles node is missing from colour scheme."}
     SchemeInvalidError:string {"Colour scheme definition is invalid."}
     ReadErrorTitle:string {"Error reading colour scheme"}
+    IndicatorKindIncorrect:string {"Indicator kind is invalid: '{value}'."}
 
     TextStyleNames:table {
       Default:string            {"Default"}
@@ -741,360 +743,41 @@ root:table {
       StringEOL:string          {"String (EOL)"}
       Keyword2:string           {"Keywords (2)"}
     }
+    
+    IndicatorStyleNames:table {
+      ActiveCode:string {"Active code"}
+      ErrorCode:string {"Active code (with runtime error)"}
+      HighlightCode:string {"Highlighted code"}
+      InteractiveText:string {"Interactive text"}
+    }
+    
+    IndicatorKindNames:table {
+      PLAIN:string       {"Underlined"}
+      BOX:string         {"Outlined"}
+      STRAIGHTBOX:string {"Highlighted"}
+    }
 
     SettingsPanel:table {
       Title:string {"Colour Scheme"}
       SaveErrorTitle:string {"Error saving colour scheme"}
       SaveErrorMessage:string {"Error saving colour scheme"}
+      
+      TextStylePicker:table {
+        FontPickerToolTip:string {"Font style"}
+        ForegroundPickerLabel:string {"Foreground:"}
+        ForegroundPickerToolTip:string {"Foreground colour"}
+        BackgroundPickerLabel:string {"Background:"}
+        BackgroundPickerToolTip:string {"Background colour"}
+      }
+      
+      IndicatorStylePicker:table {
+        KindPickerToolTip:string {"Indication"}
+        ForegroundPickerToolTip:string {"Colour"}
+        OpacityPickerLabel:string {"Opacity:"}
+        OpacityPickerToolTip:string {"Opacity"}
+        OutlineOpacityPickerLabel:string {"Outline opacity:"}
+        OutlineOpacityPickerToolTip:string {"Outline opacity"}
+      }
     }
   }
-
-  //
-  // Default style settings for Scintilla
-  //
-  ScintillaStyles:table {
-    //
-    // Common styles
-    //
-    
-    Default:table {
-      Name:string {"Default"}
-      Foreground:string {"rgb(101,123,131)"}
-      Background:string {"rgb(253,246,227)"}
-      FontName:string {""}
-      FontSize:int {12}
-      FontStyle:string {""}
-      LetterCase:int {0}
-    }
-    
-    LineNumber:table {
-      Name:string {"Line number"}
-      Foreground:string {"rgb(147,161,161)"}
-      Background:string {"rgb(238,232,213)"}
-      FontName:string {""}
-      FontSize:int {12}
-      FontStyle:string {""}
-      LetterCase:int {0}
-    }
-    
-    BraceLight:table {
-      Name:string {"Brace light"}
-      Foreground:string {"rgb(101,123,131)"}
-      Background:string {"rgb(238,232,213)"}
-      FontName:string {""}
-      FontSize:int {12}
-      FontStyle:string {""}
-      LetterCase:int {0}
-    }
-    
-    BraceBad:table {
-      Name:string {"Brace bad"}
-      Foreground:string {"rgb(101,123,131)"}
-      Background:string {"rgb(238,232,213)"}
-      FontName:string {""}
-      FontSize:int {12}
-      FontStyle:string {""}
-      LetterCase:int {0}
-    }
-    
-    ControlChar:table {
-      Name:string {"Control character"}
-      Foreground:string {"rgb(101,123,131)"}
-      Background:string {"rgb(253,246,227)"}
-      FontName:string {""}
-      FontSize:int {12}
-      FontStyle:string {""}
-      LetterCase:int {0}
-    }
-    
-    IndentGuide:table {
-      Name:string {"Indent guide"}
-      Foreground:string {"rgb(101,123,131)"}
-      Background:string {"rgb(253,246,227)"}
-      FontName:string {""}
-      FontSize:int {12}
-      FontStyle:string {""}
-      LetterCase:int {0}
-    }
-    
-    CallTip:table {
-      Name:string {"Call tip"}
-      Foreground:string {"rgb(101,123,131)"}
-      Background:string {"rgb(253,246,227)"}
-      FontName:string {""}
-      FontSize:int {12}
-      FontStyle:string {""}
-      LetterCase:int {0}
-    }
-
-    //
-    // SeeC-specific styles
-    //
-
-    SeeCRuntimeError:table {
-      Name:string {"Runtime error"}
-      Foreground:string {"rgb(220, 50, 47)"} // red
-      Background:string {"rgb(238,232,213)"} // base2
-      FontName:string {""}
-      FontSize:int {12}
-      FontStyle:string {""}
-      LetterCase:int {0}
-    }
-
-    SeeCRuntimeValue:table {
-      Name:string {"Runtime value"}
-      Foreground:string {"rgb(133,153,  0)"} // green
-      Background:string {"rgb(238,232,213)"} // base2
-      FontName:string {""}
-      FontSize:int {12}
-      FontStyle:string {""}
-      LetterCase:int {0}
-    }
-
-    SeeCRuntimeInformation:table {
-      Name:string {"Runtime information"}
-      Foreground:string {"rgb(181,137,  0)"} // yellow
-      Background:string {"rgb(238,232,213)"} // base2
-      FontName:string {""}
-      FontSize:int {12}
-      FontStyle:string {""}
-      LetterCase:int {0}
-    }
-
-    //
-    // Lexer-specific styles
-    //
-    
-    Comment:table {
-      Name:string {"Comment"}
-      Foreground:string {"rgb(147,161,161)"} // base1
-      Background:string {"rgb(253,246,227)"}
-      FontName:string {""}
-      FontSize:int {12}
-      FontStyle:string {""}
-      LetterCase:int {0}
-    }
-
-    CommentLine:table {
-      Name:string {"Comment line"}
-      Foreground:string {"rgb(147,161,161)"} // base1
-      Background:string {"rgb(253,246,227)"}
-      FontName:string {""}
-      FontSize:int {12}
-      FontStyle:string {""}
-      LetterCase:int {0}
-    }
-    
-    CommentDoc:table {
-      Name:string {"Comment (Doxygen)"}
-      Foreground:string {"rgb(147,161,161)"} // base1
-      Background:string {"rgb(253,246,227)"}
-      FontName:string {""}
-      FontSize:int {12}
-      FontStyle:string {""}
-      LetterCase:int {0}
-    }
-
-    Number:table {
-      Name:string {"Number"}
-      Foreground:string {"rgb(203, 75, 22)"} // orange
-      Background:string {"rgb(253,246,227)"}
-      FontName:string {""}
-      FontSize:int {12}
-      FontStyle:string {""}
-      LetterCase:int {0}
-    }
-    
-    Keyword1:table {
-      Name:string {"Keyword1"}
-      Foreground:string {"rgb( 88,110,117)"} // base01
-      Background:string {"rgb(253,246,227)"}
-      FontName:string {""}
-      FontSize:int {12}
-      FontStyle:string {"Bold"}
-      LetterCase:int {0}
-    }
-    
-    String:table {
-      Name:string {"String"}
-      Foreground:string {"rgb( 38,139,210)"} // blue
-      Background:string {"rgb(253,246,227)"}
-      FontName:string {""}
-      FontSize:int {12}
-      FontStyle:string {""}
-      LetterCase:int {0}
-    }
-    
-    Character:table {
-      Name:string {"Character"}
-      Foreground:string {"rgb( 42,161,152)"} // cyan
-      Background:string {"rgb(253,246,227)"}
-      FontName:string {""}
-      FontSize:int {12}
-      FontStyle:string {""}
-      LetterCase:int {0}
-    }
-
-    UUID:table {
-      Name:string {"UUID"}
-      Foreground:string {"rgb(101,123,131)"}
-      Background:string {"rgb(253,246,227)"}
-      FontName:string {""}
-      FontSize:int {12}
-      FontStyle:string {""}
-      LetterCase:int {0}
-    }
-
-    Preprocessor:table {
-      Name:string {"Preprocessor"}
-      Foreground:string {"rgb(211, 54,130)"} // magenta
-      Background:string {"rgb(253,246,227)"}
-      FontName:string {""}
-      FontSize:int {12}
-      FontStyle:string {""}
-      LetterCase:int {0}
-    }
-    
-    Operator:table {
-      Name:string {"Operator"}
-      Foreground:string {"rgb( 88,110,117)"} // base01
-      Background:string {"rgb(253,246,227)"}
-      FontName:string {""}
-      FontSize:int {12}
-      FontStyle:string {""}
-      LetterCase:int {0}
-    }
-    
-    Identifier:table {
-      Name:string {"Identifier"}
-      Foreground:string {"rgb( 88,110,117)"} // base01
-      Background:string {"rgb(253,246,227)"}
-      FontName:string {""}
-      FontSize:int {12}
-      FontStyle:string {""}
-      LetterCase:int {0}
-    }
-    
-    StringEOL:table {
-      Name:string {"String (EOL)"}
-      Foreground:string {"rgb( 38,139,210)"} // blue
-      Background:string {"rgb(253,246,227)"}
-      FontName:string {""}
-      FontSize:int {12}
-      FontStyle:string {""}
-      LetterCase:int {0}
-    }
-
-    Verbatim:table {
-      Name:string {"Verbatim"}
-      Foreground:string {"rgb(101,123,131)"}
-      Background:string {"rgb(253,246,227)"}
-      FontName:string {""}
-      FontSize:int {12}
-      FontStyle:string {""}
-      LetterCase:int {0}
-    }
-    
-    RegEx:table {
-      Name:string {"Regular expression"}
-      Foreground:string {"rgb(101,123,131)"}
-      Background:string {"rgb(253,246,227)"}
-      FontName:string {""}
-      FontSize:int {12}
-      FontStyle:string {""}
-      LetterCase:int {0}
-    }
-    
-    CommentLineDoc:table {
-      Name:string {"Comment line (Doxygen)"}
-      Foreground:string {"rgb(147,161,161)"} // base1
-      Background:string {"rgb(253,246,227)"}
-      FontName:string {""}
-      FontSize:int {12}
-      FontStyle:string {""}
-      LetterCase:int {0}
-    }
-    
-    Keyword2:table {
-      Name:string {"Keyword2"}
-      Foreground:string {"rgb( 88,110,117)"} // base01
-      Background:string {"rgb(253,246,227)"}
-      FontName:string {""}
-      FontSize:int {12}
-      FontStyle:string {""}
-      LetterCase:int {0}
-    }
-    
-    CommentDocKeyword:table {
-      Name:string {"Comment (Doxygen keyword)"}
-      Foreground:string {"rgb(211, 54,130)"} // magenta
-      Background:string {"rgb(253,246,227)"}
-      FontName:string {""}
-      FontSize:int {12}
-      FontStyle:string {""}
-      LetterCase:int {0}
-    }
-
-    CommentDocKeywordError:table {
-      Name:string {"Comment (Doxygen keyword error)"}
-      Foreground:string {"rgb(220, 50, 47)"} // red
-      Background:string {"rgb(253,246,227)"}
-      FontName:string {""}
-      FontSize:int {12}
-      FontStyle:string {""}
-      LetterCase:int {0}
-    }
-    
-    GlobalClass:table {
-      Name:string {"Global class"}
-      Foreground:string {"rgb(101,123,131)"}
-      Background:string {"rgb(253,246,227)"}
-      FontName:string {""}
-      FontSize:int {12}
-      FontStyle:string {""}
-      LetterCase:int {0}
-    }
-  }
-
-
-  //
-  // Default style settings for Scintilla
-  //
-  ScintillaIndicatorStyles:table {
-    //
-    // Currently/last active code.
-    //
-    CodeActive:table {
-      Name:string {"Active code"}
-      Style:string {"PLAIN"}
-      Foreground:string {"rgb(181,137,  0)"} // yellow
-      Alpha:int {100}
-      OutlineAlpha:int {0}
-      Under:string {"False"}
-    }
-
-    //
-    // Highlight code.
-    //
-    CodeHighlight:table {
-      Name:string {"Highlight code"}
-      Style:string {"BOX"}
-      Foreground:string {"rgb(108,113,196)"} // violet
-      Alpha:int {100}
-      OutlineAlpha:int {0}
-      Under:string {"False"}
-    }
-
-    //
-    // Interactive text (e.g. node links in explanations).
-    //
-    TextInteractive:table {
-      Name:string {"Interactive text"}
-      Style:string {"PLAIN"}
-      Foreground:string {"rgb( 38,139,210)"} // blue
-      Alpha:int {100}
-      OutlineAlpha: int {0}
-      Under:string {"False"}
-    }
-  } // End ScintillaIndicatorStyles
 }

--- a/tools/seec-trace-view/ColourSchemeSettings.hpp
+++ b/tools/seec-trace-view/ColourSchemeSettings.hpp
@@ -71,6 +71,74 @@ public:
   static seec::Maybe<TextStyle, seec::Error> fromXML(wxXmlNode const &Node);
 };
 
+/// \brief Defines an indicator style.
+///
+class IndicatorStyle
+{
+public:
+  enum class EKind {
+    Plain,
+    Box,
+    StraightBox
+  };
+  
+private:
+  EKind m_Kind;
+  
+  wxColour m_Foreground;
+  
+  int m_Alpha;
+  
+  int m_OutlineAlpha;
+
+public:
+  IndicatorStyle()
+  : m_Kind(EKind::Plain),
+    m_Foreground(*wxBLACK),
+    m_Alpha(255),
+    m_OutlineAlpha(0)
+  {}
+
+  IndicatorStyle(EKind Kind,
+                 wxColour Foreground,
+                 int Alpha,
+                 int OutlineAlpha)
+  : m_Kind(Kind),
+    m_Foreground(Foreground),
+    m_Alpha(Alpha),
+    m_OutlineAlpha(OutlineAlpha)
+  {}
+  
+  void SetKind(EKind const Kind) {
+    m_Kind = Kind;
+  }
+  
+  EKind GetKind() const { return m_Kind; }
+
+  void SetForeground(wxColour Foreground) {
+    m_Foreground = Foreground;
+  }
+
+  wxColour GetForeground() const { return m_Foreground; }
+
+  void SetAlpha(int const Alpha) {
+    m_Alpha = std::max(std::min(Alpha, 255), 0);
+  }
+  
+  int GetAlpha() const { return m_Alpha; }
+
+  void SetOutlineAlpha(int const OutlineAlpha) {
+    m_OutlineAlpha = std::max(std::min(OutlineAlpha, 255), 0);
+  }
+  
+  int GetOutlineAlpha() const { return m_OutlineAlpha; }
+
+  static seec::Maybe<IndicatorStyle, seec::Error> fromXML(wxXmlNode const &Node);
+};
+
+char const * const to_string(IndicatorStyle::EKind const Kind);
+
+
 /// \brief Defines a complete colour scheme.
 ///
 class ColourScheme
@@ -95,6 +163,11 @@ private:
   TextStyle m_StringEOL;
   TextStyle m_Keyword2;
 
+  IndicatorStyle m_ActiveCode;
+  IndicatorStyle m_ErrorCode;
+  IndicatorStyle m_HighlightCode;
+  IndicatorStyle m_InteractiveText;
+  
 public:
   ColourScheme();
 
@@ -118,6 +191,13 @@ public:
   void setStringEOL(TextStyle const &Value) { m_StringEOL = Value; }
   void setKeyword2(TextStyle const &Value) { m_Keyword2 = Value; }
 
+  void setActiveCode(IndicatorStyle const &Value) { m_ActiveCode = Value; }
+  void setErrorCode(IndicatorStyle const &Value) { m_ErrorCode = Value; }
+  void setHighlightCode(IndicatorStyle const &Value) {
+    m_HighlightCode = Value; }
+  void setInteractiveText(IndicatorStyle const &Value) {
+    m_InteractiveText = Value; }
+  
   TextStyle const &getDefault() const { return m_Default; }
   TextStyle const &getLineNumber() const { return m_LineNumber; }
 
@@ -136,6 +216,11 @@ public:
   TextStyle const &getIdentifier() const { return m_Identifier; }
   TextStyle const &getStringEOL() const { return m_StringEOL; }
   TextStyle const &getKeyword2() const { return m_Keyword2; }
+  
+  IndicatorStyle const &getActiveCode() const { return m_ActiveCode; }
+  IndicatorStyle const &getErrorCode() const { return m_ErrorCode; }
+  IndicatorStyle const &getHighlightCode() const { return m_HighlightCode; }
+  IndicatorStyle const &getInteractiveText() const { return m_InteractiveText; }
 };
 
 /// \brief Holds the application's colour scheme settings.

--- a/tools/seec-trace-view/SourceViewerSettings.cpp
+++ b/tools/seec-trace-view/SourceViewerSettings.cpp
@@ -23,193 +23,6 @@
 
 
 //===----------------------------------------------------------------------===//
-// SciCommonType
-//===----------------------------------------------------------------------===//
-
-char const *getSciTypeName(SciCommonType Type) {
-  switch (Type) {
-#define SEEC_SCI_COMMON_TYPE(TYPE, ID) \
-    case SciCommonType::TYPE: return #TYPE;
-#include "SourceViewerSettingsTypes.def"
-  }
-  
-  // Unreachable if Type is valid.
-  return nullptr;
-}
-
-seec::Maybe<SciCommonType> getSciCommonTypeFromName(llvm::StringRef Name){
-#define SEEC_SCI_COMMON_TYPE(TYPE, ID) \
-  if (Name.equals(#TYPE))   \
-    return SciCommonType::TYPE;
-#include "SourceViewerSettingsTypes.def"
-
-  return seec::Maybe<SciCommonType>();
-}
-
-
-//===----------------------------------------------------------------------===//
-// SciLexerType
-//===----------------------------------------------------------------------===//
-
-char const *getSciTypeName(SciLexerType Type) {
-  switch (Type) {
-#define SEEC_SCI_TYPE(TYPE, ID) \
-    case SciLexerType::TYPE: return #TYPE;
-#include "SourceViewerSettingsTypes.def"
-  }
-  
-  // Unreachable if Type is valid.
-  return nullptr;
-}
-
-seec::Maybe<SciLexerType> getSciLexerTypeFromName(llvm::StringRef Name) {
-#define SEEC_SCI_TYPE(TYPE, ID) \
-  if (Name.equals(#TYPE))   \
-    return SciLexerType::TYPE;
-#include "SourceViewerSettingsTypes.def"
-
-  return seec::Maybe<SciLexerType>();
-}
-
-
-//===----------------------------------------------------------------------===//
-// SciIndicatorType
-//===----------------------------------------------------------------------===//
-
-char const *getSciIndicatorTypeName(SciIndicatorType Type) {
-  switch (Type) {
-#define SEEC_SCI_INDICATOR(TYPE) \
-    case SciIndicatorType::TYPE: return #TYPE;
-#include "SourceViewerSettingsTypes.def"
-  }
-  
-  // Unreachable if Type is valid.
-  return nullptr;
-}
-
-seec::Maybe<SciIndicatorType>
-getSciIndicatorTypeFromName(llvm::StringRef Name) {
-#define SEEC_SCI_INDICATOR(TYPE) \
-  if (Name.equals(#TYPE))   \
-    return SciIndicatorType::TYPE;
-#include "SourceViewerSettingsTypes.def"
-
-  return seec::Maybe<SciIndicatorType>();
-}
-
-llvm::ArrayRef<SciIndicatorType> getAllSciIndicatorTypes() {
-  static SciIndicatorType Types[] = {
-#define SEEC_SCI_INDICATOR(TYPE) \
-    SciIndicatorType::TYPE,
-#include "SourceViewerSettingsTypes.def"
-  };
-  
-  return llvm::ArrayRef<SciIndicatorType>(Types);
-}
-
-seec::Maybe<SciIndicatorStyle>
-getDefaultIndicatorStyle(SciIndicatorType Type) {
-  // First get the name of this indicator style type.
-  auto StyleName = getSciIndicatorTypeName(Type);
-  if (!StyleName)
-    return seec::Maybe<SciIndicatorStyle>();
-  
-  // Find the default setting for this indicator style in our ICU resources.
-  UErrorCode Status = U_ZERO_ERROR;
-  auto Table = seec::getResource("TraceViewer",
-                                 getLocale(),
-                                 Status,
-                                 "ScintillaIndicatorStyles",
-                                 StyleName);
-  if (U_FAILURE(Status))
-    return seec::Maybe<SciIndicatorStyle>();
-  
-  // Get the individual values from the default setting table.
-  auto Name = seec::getwxStringExOrEmpty(Table, "Name");
-  auto StyleStr = seec::getwxStringExOrEmpty(Table, "Style");
-  auto ForegroundStr = seec::getwxStringExOrEmpty(Table, "Foreground");
-  auto Alpha = seec::getIntEx(Table, "Alpha", Status);
-  auto OutlineAlpha = seec::getIntEx(Table, "OutlineAlpha", Status);
-  auto UnderStr = seec::getwxStringExOrEmpty(Table, "Under");
-  
-  if (U_FAILURE(Status))
-    return seec::Maybe<SciIndicatorStyle>();
-  
-  // Match the style string to a style.
-  int Style = -1;
-  
-#define SEEC_MATCH_INDICATOR_STYLE(NAME)         \
-  if (StyleStr.IsSameAs(wxString(#NAME), false)) \
-    Style = wxSTC_INDIC_##NAME;
-
-  SEEC_MATCH_INDICATOR_STYLE(PLAIN)
-  SEEC_MATCH_INDICATOR_STYLE(SQUIGGLE)
-  SEEC_MATCH_INDICATOR_STYLE(TT)
-  SEEC_MATCH_INDICATOR_STYLE(DIAGONAL)
-  SEEC_MATCH_INDICATOR_STYLE(STRIKE)
-  SEEC_MATCH_INDICATOR_STYLE(HIDDEN)
-  SEEC_MATCH_INDICATOR_STYLE(BOX)
-  SEEC_MATCH_INDICATOR_STYLE(ROUNDBOX)
-  SEEC_MATCH_INDICATOR_STYLE(STRAIGHTBOX)
-  SEEC_MATCH_INDICATOR_STYLE(DASH)
-  SEEC_MATCH_INDICATOR_STYLE(DOTS)
-  SEEC_MATCH_INDICATOR_STYLE(SQUIGGLELOW)
-  SEEC_MATCH_INDICATOR_STYLE(DOTBOX)
-  
-#undef SEEC_MATCH_INDICATOR_STYLE
-
-  if (Style == -1)
-    return seec::Maybe<SciIndicatorStyle>();
-  
-  // Ensure that the alpha values are within the acceptable range.
-  if (Alpha < 0) Alpha = 0;
-  if (Alpha > 255) Alpha = 255;
-  if (OutlineAlpha < 0) OutlineAlpha = 0;
-  if (OutlineAlpha > 255) OutlineAlpha = 255;
-  
-  // Get the Under value as a bool.
-  bool Under = false;
-  
-  if (UnderStr.CmpNoCase("TRUE"))
-    Under = true;
-  else if (UnderStr.CmpNoCase("FALSE"))
-    Under = false;
-  else
-    return seec::Maybe<SciIndicatorStyle>();
-  
-  // Return the complete style.
-  return SciIndicatorStyle(wxString(StyleName),
-                           Style,
-                           wxColour(ForegroundStr),
-                           Alpha,
-                           OutlineAlpha,
-                           Under);
-}
-
-void setupAllSciIndicatorTypes(wxStyledTextCtrl &Text) {
-  for (auto const Type : getAllSciIndicatorTypes()) {
-    auto const MaybeStyle = getDefaultIndicatorStyle(Type);
-    
-    if (!MaybeStyle.assigned()) {
-      wxLogDebug("Couldn't get default style for indicator %s",
-                 getSciIndicatorTypeName(Type));
-      
-      continue;
-    }
-    
-    auto const Indicator = static_cast<int>(Type);
-    auto const &IndicatorStyle = MaybeStyle.get<0>();
-    
-    Text.IndicatorSetStyle(Indicator, IndicatorStyle.Style);
-    Text.IndicatorSetForeground(Indicator, IndicatorStyle.Foreground);
-    Text.IndicatorSetAlpha(Indicator, IndicatorStyle.Alpha);
-    Text.IndicatorSetOutlineAlpha(Indicator, IndicatorStyle.OutlineAlpha);
-    Text.IndicatorSetUnder(Indicator, IndicatorStyle.Under);
-  }
-}
-
-
-//===----------------------------------------------------------------------===//
 // ColourScheme support
 //===----------------------------------------------------------------------===//
 
@@ -247,6 +60,32 @@ void setSTCStyle(wxStyledTextCtrl &Text,
   setSTCStyle(Text, static_cast<int>(Type), Style);
 }
 
+int IndicatorKindToSTCIndicatorStyle(IndicatorStyle::EKind const Kind)
+{
+  switch (Kind)
+  {
+    case IndicatorStyle::EKind::Plain:       return wxSTC_INDIC_PLAIN;
+    case IndicatorStyle::EKind::Box:         return wxSTC_INDIC_BOX;
+    case IndicatorStyle::EKind::StraightBox: return wxSTC_INDIC_STRAIGHTBOX;
+    default:                                 return wxSTC_INDIC_PLAIN;
+  }
+}
+
+/// \brief Setup a Scintilla indicator from an \c IndicatorStyle.
+///
+void setSTCIndicator(wxStyledTextCtrl &Text,
+                     SciIndicatorType const Type,
+                     IndicatorStyle const &Style)
+{
+  auto const Indicator = static_cast<int>(Type);
+  
+  Text.IndicatorSetStyle(Indicator,
+                         IndicatorKindToSTCIndicatorStyle(Style.GetKind()));
+  Text.IndicatorSetForeground(Indicator, Style.GetForeground());
+  Text.IndicatorSetAlpha(Indicator, Style.GetAlpha());
+  Text.IndicatorSetOutlineAlpha(Indicator, Style.GetOutlineAlpha());
+}
+
 } // anonymous namespace
 
 void setupStylesFromColourScheme(wxStyledTextCtrl &Text,
@@ -277,5 +116,10 @@ void setupStylesFromColourScheme(wxStyledTextCtrl &Text,
               Scheme.getRuntimeInformation());
 
   // Setup the style settings for our indicators.
-  setupAllSciIndicatorTypes(Text);
+  setSTCIndicator(Text, SciIndicatorType::CodeActive, Scheme.getActiveCode());
+  setSTCIndicator(Text, SciIndicatorType::CodeError, Scheme.getErrorCode());
+  setSTCIndicator(Text, SciIndicatorType::CodeHighlight,
+                  Scheme.getHighlightCode());
+  setSTCIndicator(Text, SciIndicatorType::TextInteractive,
+                  Scheme.getInteractiveText());
 }

--- a/tools/seec-trace-view/SourceViewerSettings.hpp
+++ b/tools/seec-trace-view/SourceViewerSettings.hpp
@@ -39,21 +39,6 @@ enum class SciCommonType : int {
 #include "SourceViewerSettingsTypes.def"
 };
 
-/// \brief Get the name of a SciCommonType.
-///
-/// \param Type the type to get the name of.
-/// \return a pointer to a statically-allocated C string containing the name of
-///         Type.
-char const *getSciTypeName(SciCommonType Type);
-
-/// \brief Get the SciCommonType with the given name (if any).
-///
-/// \param Name the name to search for.
-/// \return a seec::Maybe<SciCommonType> which contains the SciCommonType
-///         with name equal to Name, or is unassigned if no such SciCommonType
-///         exists.
-seec::Maybe<SciCommonType> getSciCommonTypeFromName(llvm::StringRef Name);
-
 
 //===----------------------------------------------------------------------===//
 // SciLexerType
@@ -65,63 +50,6 @@ enum class SciLexerType : int {
 #define SEEC_SCI_TYPE(TYPE, ID) \
   TYPE = ID,
 #include "SourceViewerSettingsTypes.def"
-};
-
-/// \brief Get the name of a SciLexerType.
-///
-/// \param Type the type to get the name of.
-/// \return a pointer to a statically-allocated C string containing the name of
-///         Type.
-char const *getSciTypeName(SciLexerType Type);
-
-/// \brief Get the SciLexerType with the given name (if any).
-///
-/// \param Name the name to search for.
-/// \return a seec::Maybe<SciType> which contains the SciType with name
-///         equal to Name, or is unassigned if no such SciType exists.
-seec::Maybe<SciLexerType> getSciLexerTypeFromName(llvm::StringRef Name);
-
-
-//===----------------------------------------------------------------------===//
-// SciIndicatorStyle
-//===----------------------------------------------------------------------===//
-
-/// \brief Holds the details of a particular indicator style
-///
-struct SciIndicatorStyle {
-  /// \brief The name of this indicator style.
-  wxString const Name;
-  
-  /// \brief The style value for SCI_INDICSETSTYLE().
-  int const Style;
-  
-  /// \brief The foreground colour for this style.
-  wxColour const Foreground;
-  
-  /// \brief The alpha transparency for drawing fill colours.
-  int const Alpha;
-  
-  /// \brief The alpha transparency for drawing outline colours.
-  int const OutlineAlpha;
-  
-  /// \brief Set whether to draw under text.
-  bool const Under;
-  
-  /// \brief Create a new SciIndicatorStyle object.
-  ///
-  SciIndicatorStyle(wxString const &TheName,
-                    int TheStyle,
-                    wxColour const &TheForeground,
-                    int TheAlpha,
-                    int TheOutlineAlpha,
-                    bool TheUnder)
-  : Name(TheName),
-    Style(TheStyle),
-    Foreground(TheForeground),
-    Alpha(TheAlpha),
-    OutlineAlpha(TheOutlineAlpha),
-    Under(TheUnder)
-  {}
 };
 
 
@@ -136,28 +64,6 @@ enum class SciIndicatorType : int {
   TYPE,
 #include "SourceViewerSettingsTypes.def"
 };
-
-/// \brief Get the name of a SciIndicatorType.
-///
-char const *getSciIndicatorTypeName(SciIndicatorType Type);
-
-/// \brief Get the SciIndicatorType with the given name (if any).
-///
-seec::Maybe<SciIndicatorType>
-getSciIndicatorTypeFromName(llvm::StringRef Name);
-
-/// \brief Get an array containing all valid SciIndicatorType values.
-///
-llvm::ArrayRef<SciIndicatorType> getAllSciIndicatorTypes();
-
-/// \brief Get the default style settings for a given SciIndicatorType.
-///
-seec::Maybe<SciIndicatorStyle>
-getDefaultIndicatorStyle(SciIndicatorType Type);
-
-/// \brief Setup default style settings for all indicator types.
-///
-void setupAllSciIndicatorTypes(wxStyledTextCtrl &Text);
 
 
 //===----------------------------------------------------------------------===//

--- a/tools/seec-trace-view/SourceViewerSettingsTypes.def
+++ b/tools/seec-trace-view/SourceViewerSettingsTypes.def
@@ -68,6 +68,7 @@ SEEC_SCI_COMMON_TYPE(CallTip,     wxSTC_STYLE_CALLTIP)
 // SeeC Indicators
 
 SEEC_SCI_INDICATOR(CodeActive)
+SEEC_SCI_INDICATOR(CodeError)
 SEEC_SCI_INDICATOR(CodeHighlight)
 SEEC_SCI_INDICATOR(TextInteractive)
 

--- a/tools/seec-trace-view/StateEvaluationTree.hpp
+++ b/tools/seec-trace-view/StateEvaluationTree.hpp
@@ -43,6 +43,7 @@ class ActionReplayFrame;
 class ColourScheme;
 class ContextEvent;
 class ContextNotifier;
+class IndicatorStyle;
 class OpenTrace;
 class StateAccessToken;
 
@@ -133,11 +134,6 @@ class StateEvaluationTreePanel final : public wxScrolled<wxPanel>
       Error(WithError)
     {}
   };
-  
-  enum class IndicatorStyle {
-    Plain,
-    Box
-  };
 
   /// \brief Contains settings that control the display of the evaluation tree.
   ///
@@ -157,29 +153,7 @@ class StateEvaluationTreePanel final : public wxScrolled<wxPanel>
     
     int PenWidth;
     
-    wxColour Background;
-
-    wxColour Text;
-    
-    wxColour NodeBackground;
-    
-    wxColour NodeBorder;
-
-    wxColour NodeText;
-    
-    wxColour NodeActiveBackground;
-    
-    wxColour NodeActiveBorder;
-
-    wxColour NodeActiveText;
-    
-    wxColour NodeHighlightedBackground;
-    
-    wxColour NodeHighlightedBorder;
-
-    wxColour NodeHighlightedText;
-    
-    wxColour NodeErrorBorder;
+    ColourScheme const *m_ColourScheme;
     
     /// \brief Constructor.
     ///
@@ -247,9 +221,16 @@ class StateEvaluationTreePanel final : public wxScrolled<wxPanel>
   ///
   void setupColourScheme(ColourScheme const &Scheme);
 
+  /// \brief Draw the indicator decoration for a given area.
+  ///
+  void drawIndicatorAtArea(wxDC &DC, IndicatorStyle const &Style,
+                           wxCoord X, wxCoord Y,
+                           wxCoord W, wxCoord H);
+  
   /// \brief Draw a single node using the given \c wxDC.
   ///
   void drawNode(wxDC &DC,
+                ColourScheme const &Scheme,
                 NodeInfo const &Node,
                 NodeDecoration const Decoration);
 

--- a/tools/seec-trace-view/StateGraphViewer.cpp
+++ b/tools/seec-trace-view/StateGraphViewer.cpp
@@ -88,6 +88,24 @@ void convertTextStyleToJSON(llvm::raw_string_ostream &Stream,
     << "}";
 };
 
+void convertIndicatorStyleToJSON(llvm::raw_string_ostream &Stream,
+                                 llvm::StringRef StyleName,
+                                 IndicatorStyle const &Style)
+{
+  Stream
+  << '"' << StyleName << '"'
+  << ": {"
+  << "\"Kind\": \""
+  << to_string(Style.GetKind()) << "\","
+  << "\"Foreground\": \""
+  << Style.GetForeground().GetAsString().ToStdString() << "\","
+  << "\"Alpha\": "
+  << Style.GetAlpha() << ","
+  << "\"OutlineAlpha\": "
+  << Style.GetOutlineAlpha()
+  << "}";
+}
+
 std::string convertColourSchemeToJSON(ColourScheme const &Scheme)
 {
   std::string JSON;
@@ -115,9 +133,19 @@ std::string convertColourSchemeToJSON(ColourScheme const &Scheme)
   SEEC_CONVERT_TEXTSTYLE(Operator)     Stream << ',';
   SEEC_CONVERT_TEXTSTYLE(Identifier)   Stream << ',';
   SEEC_CONVERT_TEXTSTYLE(StringEOL)    Stream << ',';
-  SEEC_CONVERT_TEXTSTYLE(Keyword2)
+  SEEC_CONVERT_TEXTSTYLE(Keyword2)     Stream << ",";
 
 #undef SEEC_CONVERT_TEXTSTYLE
+
+#define SEEC_CONVERT_INDICATORSTYLE(NAME)                                      \
+  convertIndicatorStyleToJSON(Stream, #NAME, Scheme.get##NAME());
+  
+  SEEC_CONVERT_INDICATORSTYLE(ActiveCode)      Stream << ",";
+  SEEC_CONVERT_INDICATORSTYLE(ErrorCode)       Stream << ",";
+  SEEC_CONVERT_INDICATORSTYLE(HighlightCode)   Stream << ",";
+  SEEC_CONVERT_INDICATORSTYLE(InteractiveText)
+  
+#undef SEEC_CONVERT_INDICATORSTYLE
 
   Stream << "}";
 


### PR DESCRIPTION
This changes indicator styles, colours, and opacities to be
user-configurable. The same indicator settings will now be used
throughout all areas of the trace viewer (i.e. source viewer,
evaluation tree, graph, explanation).

There are currently three indicator styles supported: underlining,
outlining, and highlighting. These are modelled on the Scintilla
indicators PLAIN, BOX, and STRAIGHTBOX, respectively.
